### PR TITLE
fix: correct backend API port and ESLint config

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -3,7 +3,7 @@ module.exports = {
   env: { browser: true, es2020: true },
   extends: [
     'eslint:recommended',
-    '@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended',
     'plugin:react-hooks/recommended',
   ],
   ignorePatterns: ['dist', '.eslintrc.cjs'],

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -5,6 +5,9 @@ import { fileURLToPath } from 'url';
 const isDev = process.env.NODE_ENV === 'development';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Base URL for backend API requests
+const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:3001';
+
 let mainWindow: BrowserWindow | null = null;
 
 const createWindow = (): void => {
@@ -63,7 +66,7 @@ app.on('window-all-closed', () => {
 
 ipcMain.handle('chat:send-message', async (_, message: string) => {
   try {
-    const response = await fetch('http://localhost:3010/api/chat', {
+    const response = await fetch(`${API_BASE_URL}/api/chat`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -90,7 +93,7 @@ ipcMain.handle('chat:upload-document', async (_, filePath: string) => {
     const blob = await fileData.blob();
     formData.append('document', blob);
 
-    const response = await fetch('http://localhost:3010/api/upload', {
+    const response = await fetch(`${API_BASE_URL}/api/upload`, {
       method: 'POST',
       body: formData,
     });


### PR DESCRIPTION
## Summary
- fix mismatched API port in Electron main process and support configurable base URL
- ensure linting works by referencing plugin's TypeScript rules

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run type-check`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68a998f66fe08323a10c7e12920d1990